### PR TITLE
⚙️允许用户自定义时区

### DIFF
--- a/WutheringWavesUID/utils/database/models.py
+++ b/WutheringWavesUID/utils/database/models.py
@@ -21,6 +21,7 @@ exec_list.extend(
         'ALTER TABLE WavesUser ADD COLUMN bbs_sign_switch TEXT DEFAULT "off"',
         'ALTER TABLE WavesUser ADD COLUMN bat TEXT DEFAULT ""',
         'ALTER TABLE WavesUser ADD COLUMN did TEXT DEFAULT ""',
+        'ALTER TABLE WavesUser ADD COLUMN timezone_value TEXT DEFAULT "Asia/Shanghai"',
         'ALTER TABLE WavesPush ADD COLUMN push_time_value TEXT DEFAULT ""',
     ]
 )
@@ -120,6 +121,7 @@ class WavesUser(User, table=True):
     bbs_sign_switch: str = Field(default="off", title="自动社区签到")
     bat: str = Field(default="", title="bat")
     did: str = Field(default="", title="did")
+    timezone_value: str = Field(default="Asia/Shanghai", title="时区")
 
     @classmethod
     @with_session

--- a/WutheringWavesUID/wutheringwaves_config/__init__.py
+++ b/WutheringWavesUID/wutheringwaves_config/__init__.py
@@ -83,35 +83,35 @@ async def send_config_ev(bot: Bot, ev: Event):
         im = await set_waves_user_value(ev, func, uid, char_name)
     elif "时区" in ev.text:
         from zoneinfo import ZoneInfo, available_timezones
-        
+
         func = "时区"
         value = ev.text.replace(func, "").strip()
         if not value:
             return await bot.send(
-                "[鸣潮] 请输入正确的IANA时区名...\n\n常用时区:\n" +
-                "Asia/Shanghai (北京)\n" +
-                "Asia/Tokyo (东京)\n" +
-                "America/New_York (纽约)\n" +
-                "Europe/London (伦敦)\n" +
-                "IANA标准时区查询: https://time.is/your_time_zone\n",
+                "[鸣潮] 请输入正确的IANA时区名...\n\n常用时区:\n"
+                + "Asia/Shanghai (北京)\n"
+                + "Asia/Tokyo (东京)\n"
+                + "America/New_York (纽约)\n"
+                + "Europe/London (伦敦)\n"
+                + "IANA标准时区查询: https://time.is/your_time_zone\n",
                 at_sender,
             )
-        
+
         # 验证时区是否有效
         try:
             ZoneInfo(value)
         except Exception:
             return await bot.send(
-                f"[鸣潮] 时区【{value}】无效!\n\n" +
-                "常用时区:\n" +
-                "Asia/Shanghai (北京)\n" +
-                "Asia/Tokyo (东京)\n" +
-                "America/New_York (纽约)\n" +
-                "Europe/London (伦敦)\n" +
-                "IANA标准时区查询: https://time.is/your_time_zone\n",
+                f"[鸣潮] 时区【{value}】无效!\n\n"
+                + "常用时区:\n"
+                + "Asia/Shanghai (北京)\n"
+                + "Asia/Tokyo (东京)\n"
+                + "America/New_York (纽约)\n"
+                + "Europe/London (伦敦)\n"
+                + "IANA标准时区查询: https://time.is/your_time_zone\n",
                 at_sender,
             )
-        
+
         im = await set_waves_user_value(ev, func, uid, value)
     elif "群排行" in ev.text:
         if ev.user_pm > 3:

--- a/WutheringWavesUID/wutheringwaves_config/__init__.py
+++ b/WutheringWavesUID/wutheringwaves_config/__init__.py
@@ -82,7 +82,7 @@ async def send_config_ev(bot: Bot, ev: Event):
             )
         im = await set_waves_user_value(ev, func, uid, char_name)
     elif "时区" in ev.text:
-        from zoneinfo import ZoneInfo, available_timezones
+        from zoneinfo import ZoneInfo
 
         func = "时区"
         value = ev.text.replace(func, "").strip()

--- a/WutheringWavesUID/wutheringwaves_config/__init__.py
+++ b/WutheringWavesUID/wutheringwaves_config/__init__.py
@@ -81,6 +81,38 @@ async def send_config_ev(bot: Bot, ev: Event):
                 at_sender,
             )
         im = await set_waves_user_value(ev, func, uid, char_name)
+    elif "时区" in ev.text:
+        from zoneinfo import ZoneInfo, available_timezones
+        
+        func = "时区"
+        value = ev.text.replace(func, "").strip()
+        if not value:
+            return await bot.send(
+                "[鸣潮] 请输入正确的IANA时区名...\n\n常用时区:\n" +
+                "Asia/Shanghai (北京)\n" +
+                "Asia/Tokyo (东京)\n" +
+                "America/New_York (纽约)\n" +
+                "Europe/London (伦敦)\n" +
+                "IANA标准时区查询: https://time.is/your_time_zone\n",
+                at_sender,
+            )
+        
+        # 验证时区是否有效
+        try:
+            ZoneInfo(value)
+        except Exception:
+            return await bot.send(
+                f"[鸣潮] 时区【{value}】无效!\n\n" +
+                "常用时区:\n" +
+                "Asia/Shanghai (北京)\n" +
+                "Asia/Tokyo (东京)\n" +
+                "America/New_York (纽约)\n" +
+                "Europe/London (伦敦)\n" +
+                "IANA标准时区查询: https://time.is/your_time_zone\n",
+                at_sender,
+            )
+        
+        im = await set_waves_user_value(ev, func, uid, value)
     elif "群排行" in ev.text:
         if ev.user_pm > 3:
             return await bot.send("[鸣潮] 群排行设置需要群管理才可设置\n", at_sender)

--- a/WutheringWavesUID/wutheringwaves_config/set_config.py
+++ b/WutheringWavesUID/wutheringwaves_config/set_config.py
@@ -11,7 +11,10 @@ PUSH_MAP = {
     "体力": "resin",
     "时间": "push_time",
 }
-WAVES_USER_MAP = {"体力背景": "stamina_bg"}
+WAVES_USER_MAP = {
+    "体力背景": "stamina_bg",
+    "时区": "timezone",
+}
 
 task_name_resin = "订阅体力推送"
 

--- a/WutheringWavesUID/wutheringwaves_help/help.json
+++ b/WutheringWavesUID/wutheringwaves_help/help.json
@@ -86,7 +86,8 @@
         "need_ck": true,
         "need_sk": false,
         "need_admin": false
-      },{
+      },
+      {
         "name": "签到",
         "desc": "签到",
         "eg": "签到",
@@ -706,6 +707,14 @@
         "name": "设置体力背景",
         "desc": "设置体力背景",
         "eg": "设置体力背景长离",
+        "need_ck": false,
+        "need_sk": false,
+        "need_admin": false
+      },
+      {
+        "name": "设置体力时区",
+        "desc": "设置时区",
+        "eg": "设置时区Asia/Tokyo",
         "need_ck": false,
         "need_sk": false,
         "need_admin": false

--- a/WutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py
+++ b/WutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py
@@ -1,7 +1,8 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import time
+from zoneinfo import ZoneInfo
 
 from gsuid_core.bot import Bot
 from gsuid_core.logger import logger
@@ -241,16 +242,23 @@ async def _draw_stamina_img(ev: Event, valid: dict) -> Image.Image:
     time_img_draw = ImageDraw.Draw(time_img)
     time_img_draw.rounded_rectangle([0, 0, 190, 33], radius=15, fill=(186, 55, 42, int(0.7 * 255)))
     if refreshTimeStamp != curr_time:
-        date_from_timestamp = datetime.fromtimestamp(refreshTimeStamp)
-        now = datetime.now()
+        # 获取用户时区设置，默认为上海时间
+        user_timezone = user.timezone_value if user and user.timezone_value else "Asia/Shanghai"
+        try:
+            tz = ZoneInfo(user_timezone)
+        except Exception:
+            tz = ZoneInfo("Asia/Shanghai")
+        
+        timestamp = datetime.fromtimestamp(refreshTimeStamp, tz=tz)
+        now = datetime.now(tz=tz)
         today = now.date()
         tomorrow = today + timedelta(days=1)
 
-        remain_time = datetime.fromtimestamp(refreshTimeStamp).strftime("%m.%d %H:%M:%S")
-        if date_from_timestamp.date() == today:
-            remain_time = "今天 " + datetime.fromtimestamp(refreshTimeStamp).strftime("%H:%M:%S")
-        elif date_from_timestamp.date() == tomorrow:
-            remain_time = "明天 " + datetime.fromtimestamp(refreshTimeStamp).strftime("%H:%M:%S")
+        remain_time = timestamp.strftime("%m.%d %H:%M:%S")
+        if timestamp.date() == today:
+            remain_time = "今天 " + timestamp.strftime("%H:%M:%S")
+        elif timestamp.date() == tomorrow:
+            remain_time = "明天 " + timestamp.strftime("%H:%M:%S")
 
         time_img_draw.text((10, 15), f"{remain_time}", "white", waves_font_24, "lm")
     else:

--- a/WutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py
+++ b/WutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 import time
 from zoneinfo import ZoneInfo
@@ -248,7 +248,7 @@ async def _draw_stamina_img(ev: Event, valid: dict) -> Image.Image:
             tz = ZoneInfo(user_timezone)
         except Exception:
             tz = ZoneInfo("Asia/Shanghai")
-        
+
         timestamp = datetime.fromtimestamp(refreshTimeStamp, tz=tz)
         now = datetime.now(tz=tz)
         today = now.date()


### PR DESCRIPTION
# 允许用户自定义时区

## 概述

本次 pr 是为添加了用户自定义时区功能，允许用户根据自己所在的时区设置体力恢复时间的显示格式。

## 新功能

- **时区设置**：每个用户可以独立设置每个WavesUser的时区
- **时间显示**：体力恢复时间会根据用户设置的时区显示对应的本地时间
- **时区验证**：验证用户输入的时区是否有效是有效的IANA时区
- **默认时区**：默认使用北京时间（Asia/Shanghai）

## 具体实现

### 1. 数据库模型更新

**文件**：`WutheringWavesUID/utils/database/models.py`

- 在 `WavesUser` 模型中新增 `timezone_value` 字段
- 默认值为 `"Asia/Shanghai"`（北京时间）
- 添加数据库迁移语句以支持现有用户

```python
timezone_value: str = Field(default="Asia/Shanghai", title="时区")
```

### 2. 配置功能扩展

**文件**：`WutheringWavesUID/wutheringwaves_config/set_config.py`

- 在 `WAVES_USER_MAP` 中添加时区配置映射
- 支持用户通过配置命令设置时区

```python
WAVES_USER_MAP = {
    "体力背景": "stamina_bg",
    "时区": "timezone",
}
```

### 3. 用户命令处理

**文件**：`WutheringWavesUID/wutheringwaves_config/__init__.py`

- 添加时区设置命令处理逻辑
- 使用 `zoneinfo.ZoneInfo` 验证时区有效性
- 提供友好的错误提示和时区查询地址

### 4. 时间显示逻辑优化

**文件**：`WutheringWavesUID/wutheringwaves_stamina/draw_waves_stamina.py`

- 导入 `zoneinfo` 模块进行时区处理
- 从用户配置读取时区设置
- 使用 `datetime.fromtimestamp()` 配合 `ZoneInfo` 转换时间
- 添加异常处理，确保时区无效时fallback到默认时区

```python
from zoneinfo import ZoneInfo

# 获取用户时区设置
user_timezone = user.timezone_value if user and user.timezone_value else "Asia/Shanghai"
try:
    tz = ZoneInfo(user_timezone)
except Exception:
    tz = ZoneInfo("Asia/Shanghai")

# 转换为用户时区时间
timestamp = datetime.fromtimestamp(refreshTimeStamp, tz=tz)
now = datetime.now(tz=tz)
```

## 使用方法

用户可以通过以下命令设置时区：

```
设置时区Asia/Shanghai         # 北京时间 (UTC+8)
设置时区Asia/Tokyo            # 东京时间 (UTC+9)
设置时区America/New_York      # 纽约时间 (UTC-5/-4)
设置时区Europe/London         # 伦敦时间 (UTC+0/+1)
设置时区UTC                   # 协调世界时
```

### 命令说明

- 时区名称需使用 IANA 标准时区格式（如 `Asia/Shanghai`）
- 如果输入无效时区，系统会提示错误并显示常用时区示例
- 不输入时区名称时，系统会显示帮助信息
